### PR TITLE
chore(pact): Add PACT contract testing setup, consumer/provider tests, templates, and example APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Wallflower Environment Configuration
+
+# Server Configuration
+PORT=3000
+NODE_ENV=development
+
+# PACT Configuration
+PACT_BROKER_BASE_URL=http://localhost:9292
+PACT_BROKER_USERNAME=
+PACT_BROKER_PASSWORD=
+PACT_BROKER_TOKEN=
+
+# Logging
+LOG_LEVEL=INFO
+
+# Database (if needed in the future)
+# DATABASE_URL=
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_NAME=wallflower
+# DB_USER=
+# DB_PASSWORD=
+
+# JWT Configuration (if implementing real JWT)
+# JWT_SECRET=your-secret-key
+# JWT_EXPIRES_IN=24h
+
+# CORS Configuration
+# CORS_ORIGIN=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,110 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Grunt intermediate storage
+.grunt
+
+# Bower dependency directory
+bower_components
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons
+build/Release
+
+# Dependency directories
+jspm_packages/
+
+# TypeScript v1 declaration files
+typings/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.env.test
+.env.local
+.env.production
+
+# parcel-bundler cache
+.cache
+.parcel-cache
+
+# next.js build output
+.next
+
+# nuxt.js build output
+.nuxt
+
+# vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless
+
+# FuseBox cache
+.fusebox/
+
+# DynamoDB Local files
+.dynamodb/
+
+# TernJS port file
+.tern-port
+
+# Logs
+logs
+*.log
+
+# PACT generated files (optional - you might want to commit these)
+# pacts/
+# Uncomment above line if you don't want to commit PACT files
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Temporary files
+tmp/
+temp/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,199 @@
-# Wallflower
+# Wallflower 🌸
+
+A web application with Express APIs and comprehensive PACT contract testing.
+
+## Overview
+
+Wallflower is a modern web application built with Node.js and Express, featuring a robust API layer with comprehensive contract testing using PACT. The application includes user management, posts, and authentication endpoints with full test coverage.
+
+## Features
+
+- **RESTful APIs**: Users, Posts, and Authentication endpoints
+- **PACT Contract Testing**: Comprehensive consumer and provider tests
+- **Express.js Backend**: Modern Node.js server with middleware
+- **Mock Data**: Ready-to-use mock data for development and testing
+- **Error Handling**: Consistent error responses across all endpoints
+- **Security**: Helmet.js for security headers, CORS support
+- **Logging**: Morgan for HTTP request logging
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js (v14 or higher)
+- npm or yarn
+
+### Installation
+
+```bash
+# Clone the repository
+git clone <repository-url>
+cd wallflower
+
+# Install dependencies
+npm install
+
+# Copy environment configuration
+cp .env.example .env
+
+# Start the development server
+npm run dev
+```
+
+The server will start on `http://localhost:3000`
+
+### API Endpoints
+
+#### Health Check
+- `GET /health` - Server health status
+- `GET /` - API information
+
+#### Users API
+- `GET /api/users` - Get all users (with pagination)
+- `GET /api/users/:id` - Get user by ID
+- `POST /api/users` - Create new user
+- `PUT /api/users/:id` - Update user
+- `DELETE /api/users/:id` - Delete user
+
+#### Posts API
+- `GET /api/posts` - Get all posts (with pagination)
+- `GET /api/posts/:id` - Get post by ID
+- `POST /api/posts` - Create new post
+- `PUT /api/posts/:id` - Update post
+- `DELETE /api/posts/:id` - Delete post
+
+#### Authentication API
+- `POST /api/auth/login` - User login
+- `POST /api/auth/register` - User registration
+- `POST /api/auth/logout` - User logout
+- `GET /api/auth/profile` - Get user profile (requires auth)
+
+## PACT Contract Testing
+
+This project includes comprehensive PACT contract tests to ensure API reliability and prevent breaking changes between frontend and backend.
+
+### What is PACT?
+
+PACT is a contract testing framework that:
+- Defines contracts between service consumers (frontend) and providers (backend)
+- Generates contracts from consumer tests
+- Verifies that providers fulfill the contracts
+- Prevents breaking changes between services
+
+### Running PACT Tests
+
+```bash
+# Run all PACT tests
+npm run test:pact
+
+# Run consumer tests only
+npm run test:pact:consumer
+
+# Run provider verification only
+npm run test:pact:provider
+
+# Use the custom test runner
+node scripts/run-pact-tests.js
+```
+
+### Test Structure
+
+```
+tests/pact/
+├── consumer/           # Consumer contract tests
+│   ├── users.consumer.pact.test.js
+│   ├── posts.consumer.pact.test.js
+│   └── auth.consumer.pact.test.js
+├── provider/           # Provider verification tests
+│   └── provider.verification.test.js
+├── templates/          # Templates for new API tests
+│   └── api.consumer.template.js
+└── README.md          # Detailed PACT documentation
+```
+
+### Adding New API Tests
+
+1. Copy the template:
+   ```bash
+   cp tests/pact/templates/api.consumer.template.js tests/pact/consumer/your-api.consumer.pact.test.js
+   ```
+
+2. Customize for your API:
+   - Update API name and paths
+   - Modify test cases
+   - Add provider states
+   - Use unique port numbers
+
+3. Update provider verification to include new states
+
+## Development
+
+### Available Scripts
+
+```bash
+npm start          # Start production server
+npm run dev        # Start development server with nodemon
+npm test           # Run all tests
+npm run test:pact  # Run PACT contract tests
+```
+
+### Project Structure
+
+```
+wallflower/
+├── api/                    # API route modules
+│   ├── index.js           # Main API router
+│   ├── users.js           # Users endpoints
+│   ├── posts.js           # Posts endpoints
+│   └── auth.js            # Authentication endpoints
+├── tests/                 # Test files
+│   ├── pact/             # PACT contract tests
+│   └── setup.js          # Test configuration
+├── scripts/              # Utility scripts
+│   └── run-pact-tests.js # PACT test runner
+├── pacts/                # Generated PACT contracts
+├── logs/                 # Log files
+├── server.js             # Main server file
+├── package.json          # Dependencies and scripts
+└── README.md             # This file
+```
+
+## Testing Philosophy
+
+This project emphasizes contract testing to ensure reliable API communication:
+
+1. **Consumer Tests**: Define what the frontend expects from the API
+2. **Provider Tests**: Verify that the API meets consumer expectations
+3. **Contract Generation**: Automatic generation of contract specifications
+4. **Continuous Verification**: Prevent breaking changes during development
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Add your changes with appropriate tests
+4. Ensure all PACT tests pass
+5. Submit a pull request
+
+### Adding New APIs
+
+When adding new APIs:
+
+1. Create the API endpoint in the `api/` directory
+2. Add consumer PACT tests using the provided template
+3. Update provider verification with new states
+4. Document the new endpoints in this README
+5. Test thoroughly with both unit and contract tests
+
+## Environment Variables
+
+See `.env.example` for available configuration options:
+
+- `PORT`: Server port (default: 3000)
+- `NODE_ENV`: Environment (development/production)
+- `PACT_BROKER_BASE_URL`: PACT Broker URL for sharing contracts
+- `LOG_LEVEL`: Logging level for PACT tests
+
+## License
+
+MIT License - see LICENSE file for details

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,132 @@
+const express = require('express');
+const router = express.Router();
+
+// Mock authentication data
+const mockUsers = [
+  { id: 1, email: 'john@example.com', password: 'password123', name: 'John Doe' },
+  { id: 2, email: 'jane@example.com', password: 'password456', name: 'Jane Smith' }
+];
+
+// POST /api/auth/login - User login
+router.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  
+  if (!email || !password) {
+    return res.status(400).json({
+      error: 'Validation error',
+      message: 'Email and password are required'
+    });
+  }
+  
+  const user = mockUsers.find(u => u.email === email && u.password === password);
+  
+  if (!user) {
+    return res.status(401).json({
+      error: 'Authentication failed',
+      message: 'Invalid email or password'
+    });
+  }
+  
+  // In a real app, you'd generate a JWT token here
+  const token = `mock-jwt-token-${user.id}-${Date.now()}`;
+  
+  res.json({
+    message: 'Login successful',
+    token,
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name
+    }
+  });
+});
+
+// POST /api/auth/register - User registration
+router.post('/register', (req, res) => {
+  const { email, password, name } = req.body;
+  
+  if (!email || !password || !name) {
+    return res.status(400).json({
+      error: 'Validation error',
+      message: 'Email, password, and name are required'
+    });
+  }
+  
+  // Check if user already exists
+  const existingUser = mockUsers.find(u => u.email === email);
+  if (existingUser) {
+    return res.status(409).json({
+      error: 'Conflict',
+      message: 'User with this email already exists'
+    });
+  }
+  
+  const newUser = {
+    id: Math.max(...mockUsers.map(u => u.id)) + 1,
+    email,
+    password, // In a real app, you'd hash this
+    name
+  };
+  
+  mockUsers.push(newUser);
+  
+  res.status(201).json({
+    message: 'Registration successful',
+    user: {
+      id: newUser.id,
+      email: newUser.email,
+      name: newUser.name
+    }
+  });
+});
+
+// POST /api/auth/logout - User logout
+router.post('/logout', (req, res) => {
+  // In a real app, you'd invalidate the token here
+  res.json({
+    message: 'Logout successful'
+  });
+});
+
+// GET /api/auth/profile - Get user profile (requires authentication)
+router.get('/profile', (req, res) => {
+  const authHeader = req.headers.authorization;
+  
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Authentication token required'
+    });
+  }
+  
+  const token = authHeader.substring(7);
+  
+  // Mock token validation
+  if (!token.startsWith('mock-jwt-token-')) {
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Invalid authentication token'
+    });
+  }
+  
+  // Extract user ID from mock token
+  const userId = parseInt(token.split('-')[3]);
+  const user = mockUsers.find(u => u.id === userId);
+  
+  if (!user) {
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'User not found'
+    });
+  }
+  
+  res.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name
+    }
+  });
+});
+
+module.exports = router;

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+
+// Import route modules
+const usersRoutes = require('./users');
+const postsRoutes = require('./posts');
+const authRoutes = require('./auth');
+
+// API info endpoint
+router.get('/', (req, res) => {
+  res.json({
+    message: 'Wallflower API v1.0.0',
+    endpoints: {
+      users: '/api/users',
+      posts: '/api/posts',
+      auth: '/api/auth'
+    },
+    timestamp: new Date().toISOString()
+  });
+});
+
+// Mount route modules
+router.use('/users', usersRoutes);
+router.use('/posts', postsRoutes);
+router.use('/auth', authRoutes);
+
+module.exports = router;

--- a/api/posts.js
+++ b/api/posts.js
@@ -1,0 +1,134 @@
+const express = require('express');
+const router = express.Router();
+
+// Mock data for demonstration
+let posts = [
+  { 
+    id: 1, 
+    title: 'Welcome to Wallflower', 
+    content: 'This is the first post on our platform.',
+    authorId: 1,
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z'
+  },
+  { 
+    id: 2, 
+    title: 'Getting Started Guide', 
+    content: 'Here\'s how to get started with our application.',
+    authorId: 2,
+    createdAt: '2023-01-02T00:00:00Z',
+    updatedAt: '2023-01-02T00:00:00Z'
+  }
+];
+
+// GET /api/posts - Get all posts
+router.get('/', (req, res) => {
+  const { page = 1, limit = 10, authorId } = req.query;
+  
+  let filteredPosts = posts;
+  if (authorId) {
+    filteredPosts = posts.filter(post => post.authorId === parseInt(authorId));
+  }
+  
+  const startIndex = (page - 1) * limit;
+  const endIndex = page * limit;
+  const paginatedPosts = filteredPosts.slice(startIndex, endIndex);
+  
+  res.json({
+    posts: paginatedPosts,
+    pagination: {
+      page: parseInt(page),
+      limit: parseInt(limit),
+      total: filteredPosts.length,
+      totalPages: Math.ceil(filteredPosts.length / limit)
+    }
+  });
+});
+
+// GET /api/posts/:id - Get post by ID
+router.get('/:id', (req, res) => {
+  const postId = parseInt(req.params.id);
+  const post = posts.find(p => p.id === postId);
+  
+  if (!post) {
+    return res.status(404).json({
+      error: 'Post not found',
+      message: `Post with ID ${postId} does not exist`
+    });
+  }
+  
+  res.json({ post });
+});
+
+// POST /api/posts - Create new post
+router.post('/', (req, res) => {
+  const { title, content, authorId } = req.body;
+  
+  if (!title || !content || !authorId) {
+    return res.status(400).json({
+      error: 'Validation error',
+      message: 'Title, content, and authorId are required'
+    });
+  }
+  
+  const newPost = {
+    id: Math.max(...posts.map(p => p.id)) + 1,
+    title,
+    content,
+    authorId: parseInt(authorId),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  };
+  
+  posts.push(newPost);
+  
+  res.status(201).json({
+    message: 'Post created successfully',
+    post: newPost
+  });
+});
+
+// PUT /api/posts/:id - Update post
+router.put('/:id', (req, res) => {
+  const postId = parseInt(req.params.id);
+  const postIndex = posts.findIndex(p => p.id === postId);
+  
+  if (postIndex === -1) {
+    return res.status(404).json({
+      error: 'Post not found',
+      message: `Post with ID ${postId} does not exist`
+    });
+  }
+  
+  const { title, content } = req.body;
+  
+  if (title) posts[postIndex].title = title;
+  if (content) posts[postIndex].content = content;
+  posts[postIndex].updatedAt = new Date().toISOString();
+  
+  res.json({
+    message: 'Post updated successfully',
+    post: posts[postIndex]
+  });
+});
+
+// DELETE /api/posts/:id - Delete post
+router.delete('/:id', (req, res) => {
+  const postId = parseInt(req.params.id);
+  const postIndex = posts.findIndex(p => p.id === postId);
+  
+  if (postIndex === -1) {
+    return res.status(404).json({
+      error: 'Post not found',
+      message: `Post with ID ${postId} does not exist`
+    });
+  }
+  
+  posts.splice(postIndex, 1);
+  
+  res.json({
+    message: 'Post deleted successfully'
+  });
+});
+
+module.exports = router;

--- a/api/users.js
+++ b/api/users.js
@@ -1,0 +1,128 @@
+const express = require('express');
+const router = express.Router();
+
+// Mock data for demonstration
+let users = [
+  { id: 1, name: 'John Doe', email: 'john@example.com', role: 'user' },
+  { id: 2, name: 'Jane Smith', email: 'jane@example.com', role: 'admin' },
+  { id: 3, name: 'Bob Johnson', email: 'bob@example.com', role: 'user' }
+];
+
+// GET /api/users - Get all users
+router.get('/', (req, res) => {
+  const { page = 1, limit = 10, role } = req.query;
+  
+  let filteredUsers = users;
+  if (role) {
+    filteredUsers = users.filter(user => user.role === role);
+  }
+  
+  const startIndex = (page - 1) * limit;
+  const endIndex = page * limit;
+  const paginatedUsers = filteredUsers.slice(startIndex, endIndex);
+  
+  res.json({
+    users: paginatedUsers,
+    pagination: {
+      page: parseInt(page),
+      limit: parseInt(limit),
+      total: filteredUsers.length,
+      totalPages: Math.ceil(filteredUsers.length / limit)
+    }
+  });
+});
+
+// GET /api/users/:id - Get user by ID
+router.get('/:id', (req, res) => {
+  const userId = parseInt(req.params.id);
+  const user = users.find(u => u.id === userId);
+  
+  if (!user) {
+    return res.status(404).json({
+      error: 'User not found',
+      message: `User with ID ${userId} does not exist`
+    });
+  }
+  
+  res.json({ user });
+});
+
+// POST /api/users - Create new user
+router.post('/', (req, res) => {
+  const { name, email, role = 'user' } = req.body;
+  
+  if (!name || !email) {
+    return res.status(400).json({
+      error: 'Validation error',
+      message: 'Name and email are required'
+    });
+  }
+  
+  // Check if email already exists
+  const existingUser = users.find(u => u.email === email);
+  if (existingUser) {
+    return res.status(409).json({
+      error: 'Conflict',
+      message: 'User with this email already exists'
+    });
+  }
+  
+  const newUser = {
+    id: Math.max(...users.map(u => u.id)) + 1,
+    name,
+    email,
+    role
+  };
+  
+  users.push(newUser);
+  
+  res.status(201).json({
+    message: 'User created successfully',
+    user: newUser
+  });
+});
+
+// PUT /api/users/:id - Update user
+router.put('/:id', (req, res) => {
+  const userId = parseInt(req.params.id);
+  const userIndex = users.findIndex(u => u.id === userId);
+  
+  if (userIndex === -1) {
+    return res.status(404).json({
+      error: 'User not found',
+      message: `User with ID ${userId} does not exist`
+    });
+  }
+  
+  const { name, email, role } = req.body;
+  
+  if (name) users[userIndex].name = name;
+  if (email) users[userIndex].email = email;
+  if (role) users[userIndex].role = role;
+  
+  res.json({
+    message: 'User updated successfully',
+    user: users[userIndex]
+  });
+});
+
+// DELETE /api/users/:id - Delete user
+router.delete('/:id', (req, res) => {
+  const userId = parseInt(req.params.id);
+  const userIndex = users.findIndex(u => u.id === userId);
+  
+  if (userIndex === -1) {
+    return res.status(404).json({
+      error: 'User not found',
+      message: `User with ID ${userId} does not exist`
+    });
+  }
+  
+  users.splice(userIndex, 1);
+  
+  res.json({
+    message: 'User deleted successfully'
+  });
+});
+
+module.exports = router;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "wallflower",
+  "version": "1.0.0",
+  "description": "Wallflower web application with Express APIs",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "jest",
+    "test:pact": "jest --testPathPattern=pact",
+    "test:pact:consumer": "jest --testPathPattern=consumer",
+    "test:pact:provider": "jest --testPathPattern=provider",
+    "pact:publish": "pact-broker publish ./pacts --consumer-app-version=$npm_package_version --broker-base-url=$PACT_BROKER_BASE_URL",
+    "pact:verify": "pact-provider-verifier --provider-base-url=http://localhost:3000 --pact-broker-base-url=$PACT_BROKER_BASE_URL --provider=wallflower-api --provider-version=$npm_package_version"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "helmet": "^7.0.0",
+    "morgan": "^1.10.0",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "jest": "^29.6.2",
+    "@pact-foundation/pact": "^12.1.0",
+    "@pact-foundation/pact-node": "^10.17.7",
+    "pact-provider-verifier": "^10.17.7",
+    "nodemon": "^3.0.1",
+    "supertest": "^6.3.3",
+    "@types/jest": "^29.5.3",
+    "axios": "^1.4.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "setupFilesAfterEnv": ["<rootDir>/tests/setup.js"],
+    "testMatch": [
+      "**/tests/**/*.test.js",
+      "**/tests/**/*.pact.test.js"
+    ]
+  },
+  "keywords": [
+    "express",
+    "api",
+    "pact",
+    "contract-testing",
+    "wallflower"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/scripts/run-pact-tests.js
+++ b/scripts/run-pact-tests.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+/**
+ * PACT Test Runner Script
+ * 
+ * This script provides a convenient way to run PACT tests with proper setup and cleanup.
+ * It handles starting/stopping the provider server and running tests in the correct order.
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Configuration
+const PROVIDER_PORT = 3001;
+const PROVIDER_TIMEOUT = 10000; // 10 seconds
+
+// Colors for console output
+const colors = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m'
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function createDirectories() {
+  const dirs = ['logs', 'pacts'];
+  dirs.forEach(dir => {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+      log(`Created directory: ${dir}`, 'cyan');
+    }
+  });
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    log(`Running: ${command} ${args.join(' ')}`, 'blue');
+    
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: true,
+      ...options
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(code);
+      } else {
+        reject(new Error(`Command failed with exit code ${code}`));
+      }
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+function startProviderServer() {
+  return new Promise((resolve, reject) => {
+    log('Starting provider server...', 'yellow');
+    
+    const server = spawn('node', ['server.js'], {
+      env: { ...process.env, PORT: PROVIDER_PORT },
+      stdio: 'pipe'
+    });
+
+    let serverReady = false;
+    const timeout = setTimeout(() => {
+      if (!serverReady) {
+        server.kill();
+        reject(new Error('Provider server failed to start within timeout'));
+      }
+    }, PROVIDER_TIMEOUT);
+
+    server.stdout.on('data', (data) => {
+      const output = data.toString();
+      if (output.includes(`running on port ${PROVIDER_PORT}`)) {
+        serverReady = true;
+        clearTimeout(timeout);
+        log(`Provider server started on port ${PROVIDER_PORT}`, 'green');
+        resolve(server);
+      }
+    });
+
+    server.stderr.on('data', (data) => {
+      console.error(data.toString());
+    });
+
+    server.on('close', (code) => {
+      if (!serverReady) {
+        clearTimeout(timeout);
+        reject(new Error(`Provider server exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function runConsumerTests() {
+  log('Running consumer tests...', 'magenta');
+  try {
+    await runCommand('npx', ['jest', '--testPathPattern=consumer', '--verbose']);
+    log('Consumer tests completed successfully!', 'green');
+    return true;
+  } catch (error) {
+    log('Consumer tests failed!', 'red');
+    console.error(error.message);
+    return false;
+  }
+}
+
+async function runProviderTests() {
+  log('Running provider verification tests...', 'magenta');
+  
+  let server;
+  try {
+    // Start provider server
+    server = await startProviderServer();
+    
+    // Wait a bit for server to be fully ready
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
+    // Run provider tests
+    await runCommand('npx', ['jest', '--testPathPattern=provider', '--verbose']);
+    log('Provider tests completed successfully!', 'green');
+    return true;
+  } catch (error) {
+    log('Provider tests failed!', 'red');
+    console.error(error.message);
+    return false;
+  } finally {
+    if (server) {
+      log('Stopping provider server...', 'yellow');
+      server.kill();
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0] || 'all';
+
+  log('🌸 Wallflower PACT Test Runner', 'bright');
+  log('================================', 'bright');
+
+  // Create necessary directories
+  createDirectories();
+
+  try {
+    switch (command) {
+      case 'consumer':
+        await runConsumerTests();
+        break;
+      
+      case 'provider':
+        await runProviderTests();
+        break;
+      
+      case 'all':
+      default:
+        log('Running all PACT tests...', 'cyan');
+        
+        const consumerSuccess = await runConsumerTests();
+        if (!consumerSuccess) {
+          process.exit(1);
+        }
+        
+        const providerSuccess = await runProviderTests();
+        if (!providerSuccess) {
+          process.exit(1);
+        }
+        
+        log('🎉 All PACT tests completed successfully!', 'green');
+        break;
+      
+      case 'help':
+        log('Usage: node scripts/run-pact-tests.js [command]', 'cyan');
+        log('Commands:', 'cyan');
+        log('  consumer  - Run consumer tests only', 'cyan');
+        log('  provider  - Run provider tests only', 'cyan');
+        log('  all       - Run all tests (default)', 'cyan');
+        log('  help      - Show this help message', 'cyan');
+        break;
+      
+      default:
+        log(`Unknown command: ${command}`, 'red');
+        log('Use "help" to see available commands', 'yellow');
+        process.exit(1);
+    }
+  } catch (error) {
+    log('Test execution failed!', 'red');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+// Handle process termination
+process.on('SIGINT', () => {
+  log('\nReceived SIGINT, cleaning up...', 'yellow');
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  log('\nReceived SIGTERM, cleaning up...', 'yellow');
+  process.exit(0);
+});
+
+if (require.main === module) {
+  main();
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const morgan = require('morgan');
+require('dotenv').config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Middleware
+app.use(helmet());
+app.use(cors());
+app.use(morgan('combined'));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Import API routes
+const apiRoutes = require('./api');
+
+// Use API routes
+app.use('/api', apiRoutes);
+
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.status(200).json({
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime()
+  });
+});
+
+// Root endpoint
+app.get('/', (req, res) => {
+  res.json({
+    message: 'Welcome to Wallflower API',
+    version: '1.0.0',
+    endpoints: {
+      health: '/health',
+      api: '/api'
+    }
+  });
+});
+
+// 404 handler
+app.use('*', (req, res) => {
+  res.status(404).json({
+    error: 'Not Found',
+    message: `Route ${req.originalUrl} not found`,
+    timestamp: new Date().toISOString()
+  });
+});
+
+// Error handler
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  res.status(500).json({
+    error: 'Internal Server Error',
+    message: process.env.NODE_ENV === 'production' ? 'Something went wrong!' : err.message,
+    timestamp: new Date().toISOString()
+  });
+});
+
+// Start server
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Wallflower server running on port ${PORT}`);
+    console.log(`Health check: http://localhost:${PORT}/health`);
+    console.log(`API base: http://localhost:${PORT}/api`);
+  });
+}
+
+module.exports = app;

--- a/tests/integration/api.integration.test.js
+++ b/tests/integration/api.integration.test.js
@@ -1,0 +1,162 @@
+const request = require('supertest');
+const app = require('../../server');
+
+describe('API Integration Tests', () => {
+  describe('Health Check', () => {
+    it('should return health status', async () => {
+      const response = await request(app)
+        .get('/health')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('status', 'healthy');
+      expect(response.body).toHaveProperty('timestamp');
+      expect(response.body).toHaveProperty('uptime');
+    });
+  });
+
+  describe('Root Endpoint', () => {
+    it('should return API information', async () => {
+      const response = await request(app)
+        .get('/')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('message', 'Welcome to Wallflower API');
+      expect(response.body).toHaveProperty('version', '1.0.0');
+      expect(response.body).toHaveProperty('endpoints');
+    });
+  });
+
+  describe('Users API', () => {
+    it('should get all users', async () => {
+      const response = await request(app)
+        .get('/api/users')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('users');
+      expect(response.body).toHaveProperty('pagination');
+      expect(Array.isArray(response.body.users)).toBe(true);
+    });
+
+    it('should get user by ID', async () => {
+      const response = await request(app)
+        .get('/api/users/1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('user');
+      expect(response.body.user).toHaveProperty('id', 1);
+    });
+
+    it('should create new user', async () => {
+      const newUser = {
+        name: 'Test User',
+        email: 'test@example.com',
+        role: 'user'
+      };
+
+      const response = await request(app)
+        .post('/api/users')
+        .send(newUser)
+        .expect(201);
+
+      expect(response.body).toHaveProperty('message', 'User created successfully');
+      expect(response.body).toHaveProperty('user');
+      expect(response.body.user).toHaveProperty('name', 'Test User');
+    });
+  });
+
+  describe('Posts API', () => {
+    it('should get all posts', async () => {
+      const response = await request(app)
+        .get('/api/posts')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('posts');
+      expect(response.body).toHaveProperty('pagination');
+      expect(Array.isArray(response.body.posts)).toBe(true);
+    });
+
+    it('should create new post', async () => {
+      const newPost = {
+        title: 'Test Post',
+        content: 'This is a test post.',
+        authorId: 1
+      };
+
+      const response = await request(app)
+        .post('/api/posts')
+        .send(newPost)
+        .expect(201);
+
+      expect(response.body).toHaveProperty('message', 'Post created successfully');
+      expect(response.body).toHaveProperty('post');
+      expect(response.body.post).toHaveProperty('title', 'Test Post');
+    });
+  });
+
+  describe('Auth API', () => {
+    it('should login with valid credentials', async () => {
+      const loginData = {
+        email: 'john@example.com',
+        password: 'password123'
+      };
+
+      const response = await request(app)
+        .post('/api/auth/login')
+        .send(loginData)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('message', 'Login successful');
+      expect(response.body).toHaveProperty('token');
+      expect(response.body).toHaveProperty('user');
+    });
+
+    it('should register new user', async () => {
+      const registrationData = {
+        email: 'newuser@example.com',
+        password: 'password123',
+        name: 'New User'
+      };
+
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send(registrationData)
+        .expect(201);
+
+      expect(response.body).toHaveProperty('message', 'Registration successful');
+      expect(response.body).toHaveProperty('user');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return 404 for non-existent routes', async () => {
+      const response = await request(app)
+        .get('/api/nonexistent')
+        .expect(404);
+
+      expect(response.body).toHaveProperty('error', 'Not Found');
+      expect(response.body).toHaveProperty('message');
+    });
+
+    it('should return 404 for non-existent user', async () => {
+      const response = await request(app)
+        .get('/api/users/999')
+        .expect(404);
+
+      expect(response.body).toHaveProperty('error', 'User not found');
+    });
+
+    it('should return 400 for invalid user data', async () => {
+      const invalidUser = {
+        name: 'Test User'
+        // Missing email
+      };
+
+      const response = await request(app)
+        .post('/api/users')
+        .send(invalidUser)
+        .expect(400);
+
+      expect(response.body).toHaveProperty('error', 'Validation error');
+    });
+  });
+});

--- a/tests/pact/README.md
+++ b/tests/pact/README.md
@@ -1,0 +1,175 @@
+# PACT Contract Testing for Wallflower
+
+This directory contains PACT contract tests for the Wallflower API. PACT is a contract testing framework that ensures the API provider (backend) and consumer (frontend) can communicate correctly.
+
+## Directory Structure
+
+```
+tests/pact/
+├── consumer/           # Consumer contract tests
+│   ├── users.consumer.pact.test.js
+│   ├── posts.consumer.pact.test.js
+│   └── auth.consumer.pact.test.js
+├── provider/           # Provider verification tests
+│   └── provider.verification.test.js
+├── templates/          # Templates for new API tests
+│   └── api.consumer.template.js
+└── README.md          # This file
+```
+
+## What is PACT?
+
+PACT is a contract testing tool that:
+- Defines contracts between service consumers and providers
+- Generates contracts from consumer tests
+- Verifies that providers fulfill the contracts
+- Prevents breaking changes between services
+
+## Running Tests
+
+### Consumer Tests
+Consumer tests define what the frontend expects from the API:
+
+```bash
+# Run all consumer tests
+npm run test:pact:consumer
+
+# Run specific consumer test
+npx jest tests/pact/consumer/users.consumer.pact.test.js
+```
+
+### Provider Tests
+Provider tests verify that the API meets the consumer contracts:
+
+```bash
+# Run provider verification
+npm run test:pact:provider
+
+# Run specific provider test
+npx jest tests/pact/provider/provider.verification.test.js
+```
+
+### All PACT Tests
+```bash
+# Run all PACT tests
+npm run test:pact
+```
+
+## Generated Contracts
+
+Consumer tests generate PACT files in the `pacts/` directory:
+- `wallflower-frontend-wallflower-api.json`
+
+These files contain the contract specifications that the provider must fulfill.
+
+## Adding New API Tests
+
+1. **Copy the template:**
+   ```bash
+   cp tests/pact/templates/api.consumer.template.js tests/pact/consumer/your-api.consumer.pact.test.js
+   ```
+
+2. **Customize the template:**
+   - Replace `YourAPI` with your API name
+   - Replace `your-api` with your API path
+   - Update the port number (use unique ports)
+   - Modify test cases for your endpoints
+   - Update provider states
+
+3. **Add provider states:**
+   Update `tests/pact/provider/provider.verification.test.js` to include state handlers for your new API.
+
+## Best Practices
+
+### Consumer Tests
+- Test the happy path and common error scenarios
+- Use realistic test data
+- Keep tests focused on the contract, not implementation details
+- Use unique ports for each API to avoid conflicts
+
+### Provider States
+- Set up the exact state described in the consumer test
+- Reset state between tests
+- Use descriptive state names
+
+### Contract Design
+- Design contracts from the consumer's perspective
+- Include all required fields in responses
+- Test error responses (400, 401, 404, 500)
+- Use consistent error response formats
+
+## Example Test Structure
+
+```javascript
+describe('API Consumer Contract Tests', () => {
+  let provider;
+
+  beforeAll(() => {
+    provider = new Pact({
+      consumer: 'wallflower-frontend',
+      provider: 'wallflower-api',
+      port: 1234, // Unique port
+      // ... other config
+    });
+    return provider.setup();
+  });
+
+  afterAll(() => provider.finalize());
+  afterEach(() => provider.verify());
+
+  describe('GET /api/endpoint', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'data exists',
+        uponReceiving: 'a request for data',
+        withRequest: {
+          method: 'GET',
+          path: '/api/endpoint',
+          headers: { 'Accept': 'application/json' }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+          body: { /* expected response */ }
+        }
+      };
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return expected data', async () => {
+      // Test implementation
+    });
+  });
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Port conflicts:** Each consumer test must use a unique port
+2. **State setup:** Ensure provider states match consumer expectations
+3. **Response format:** Check that actual API responses match contract expectations
+4. **Headers:** Include all required headers in both requests and responses
+
+### Debugging
+
+- Check the generated PACT files in `pacts/` directory
+- Review logs in `logs/pact.log`
+- Use `LOG_LEVEL=DEBUG` for more detailed logging
+- Verify that the provider is running on the correct port during verification
+
+## Integration with CI/CD
+
+To integrate PACT tests with your CI/CD pipeline:
+
+1. **Consumer tests:** Run during frontend builds
+2. **Provider tests:** Run during backend builds
+3. **PACT Broker:** Use a PACT Broker to share contracts between teams
+4. **Can-I-Deploy:** Use PACT's can-i-deploy tool to check deployment safety
+
+## Resources
+
+- [PACT Documentation](https://docs.pact.io/)
+- [PACT JavaScript Guide](https://github.com/pact-foundation/pact-js)
+- [Contract Testing Best Practices](https://docs.pact.io/best_practices/)

--- a/tests/pact/consumer/auth.consumer.pact.test.js
+++ b/tests/pact/consumer/auth.consumer.pact.test.js
@@ -1,0 +1,291 @@
+const { Pact } = require('@pact-foundation/pact');
+const axios = require('axios');
+const path = require('path');
+
+describe('Auth API Consumer Contract Tests', () => {
+  let provider;
+
+  beforeAll(() => {
+    provider = new Pact({
+      consumer: 'wallflower-frontend',
+      provider: 'wallflower-api',
+      port: 1236,
+      log: path.resolve(process.cwd(), 'logs', 'pact.log'),
+      dir: path.resolve(process.cwd(), 'pacts'),
+      logLevel: 'INFO',
+      spec: 2
+    });
+
+    return provider.setup();
+  });
+
+  afterAll(() => {
+    return provider.finalize();
+  });
+
+  afterEach(() => {
+    return provider.verify();
+  });
+
+  describe('POST /api/auth/login', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'user with email john@example.com exists',
+        uponReceiving: 'a valid login request',
+        withRequest: {
+          method: 'POST',
+          path: '/api/auth/login',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: {
+            email: 'john@example.com',
+            password: 'password123'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            message: 'Login successful',
+            token: 'mock-jwt-token-1-1691748000000',
+            user: {
+              id: 1,
+              email: 'john@example.com',
+              name: 'John Doe'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should successfully login with valid credentials', async () => {
+      const loginData = {
+        email: 'john@example.com',
+        password: 'password123'
+      };
+
+      const response = await axios.post('http://localhost:1236/api/auth/login', loginData, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('message', 'Login successful');
+      expect(response.data).toHaveProperty('token');
+      expect(response.data).toHaveProperty('user');
+      expect(response.data.user).toHaveProperty('id');
+      expect(response.data.user).toHaveProperty('email', 'john@example.com');
+      expect(response.data.user).toHaveProperty('name');
+    });
+  });
+
+  describe('POST /api/auth/login - Invalid credentials', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'any state',
+        uponReceiving: 'an invalid login request',
+        withRequest: {
+          method: 'POST',
+          path: '/api/auth/login',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: {
+            email: 'invalid@example.com',
+            password: 'wrongpassword'
+          }
+        },
+        willRespondWith: {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            error: 'Authentication failed',
+            message: 'Invalid email or password'
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return 401 for invalid credentials', async () => {
+      const loginData = {
+        email: 'invalid@example.com',
+        password: 'wrongpassword'
+      };
+
+      try {
+        await axios.post('http://localhost:1236/api/auth/login', loginData, {
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          }
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(401);
+        expect(error.response.data).toHaveProperty('error', 'Authentication failed');
+        expect(error.response.data).toHaveProperty('message', 'Invalid email or password');
+      }
+    });
+  });
+
+  describe('POST /api/auth/register', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'no user with email newuser@example.com exists',
+        uponReceiving: 'a valid registration request',
+        withRequest: {
+          method: 'POST',
+          path: '/api/auth/register',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: {
+            email: 'newuser@example.com',
+            password: 'newpassword123',
+            name: 'New User'
+          }
+        },
+        willRespondWith: {
+          status: 201,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            message: 'Registration successful',
+            user: {
+              id: 3,
+              email: 'newuser@example.com',
+              name: 'New User'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should successfully register a new user', async () => {
+      const registrationData = {
+        email: 'newuser@example.com',
+        password: 'newpassword123',
+        name: 'New User'
+      };
+
+      const response = await axios.post('http://localhost:1236/api/auth/register', registrationData, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        }
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data).toHaveProperty('message', 'Registration successful');
+      expect(response.data).toHaveProperty('user');
+      expect(response.data.user).toHaveProperty('id');
+      expect(response.data.user).toHaveProperty('email', 'newuser@example.com');
+      expect(response.data.user).toHaveProperty('name', 'New User');
+    });
+  });
+
+  describe('GET /api/auth/profile', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'user is authenticated with valid token',
+        uponReceiving: 'a request for user profile with valid token',
+        withRequest: {
+          method: 'GET',
+          path: '/api/auth/profile',
+          headers: {
+            'Authorization': 'Bearer mock-jwt-token-1-1691748000000',
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            user: {
+              id: 1,
+              email: 'john@example.com',
+              name: 'John Doe'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return user profile with valid token', async () => {
+      const response = await axios.get('http://localhost:1236/api/auth/profile', {
+        headers: {
+          'Authorization': 'Bearer mock-jwt-token-1-1691748000000',
+          'Accept': 'application/json'
+        }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('user');
+      expect(response.data.user).toHaveProperty('id', 1);
+      expect(response.data.user).toHaveProperty('email', 'john@example.com');
+      expect(response.data.user).toHaveProperty('name', 'John Doe');
+    });
+  });
+
+  describe('GET /api/auth/profile - Unauthorized', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'any state',
+        uponReceiving: 'a request for user profile without token',
+        withRequest: {
+          method: 'GET',
+          path: '/api/auth/profile',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            error: 'Unauthorized',
+            message: 'Authentication token required'
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return 401 when no token provided', async () => {
+      try {
+        await axios.get('http://localhost:1236/api/auth/profile', {
+          headers: {
+            'Accept': 'application/json'
+          }
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(401);
+        expect(error.response.data).toHaveProperty('error', 'Unauthorized');
+        expect(error.response.data).toHaveProperty('message', 'Authentication token required');
+      }
+    });
+  });
+});

--- a/tests/pact/consumer/posts.consumer.pact.test.js
+++ b/tests/pact/consumer/posts.consumer.pact.test.js
@@ -1,0 +1,254 @@
+const { Pact } = require('@pact-foundation/pact');
+const axios = require('axios');
+const path = require('path');
+
+describe('Posts API Consumer Contract Tests', () => {
+  let provider;
+
+  beforeAll(() => {
+    provider = new Pact({
+      consumer: 'wallflower-frontend',
+      provider: 'wallflower-api',
+      port: 1235,
+      log: path.resolve(process.cwd(), 'logs', 'pact.log'),
+      dir: path.resolve(process.cwd(), 'pacts'),
+      logLevel: 'INFO',
+      spec: 2
+    });
+
+    return provider.setup();
+  });
+
+  afterAll(() => {
+    return provider.finalize();
+  });
+
+  afterEach(() => {
+    return provider.verify();
+  });
+
+  describe('GET /api/posts', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'posts exist',
+        uponReceiving: 'a request for all posts',
+        withRequest: {
+          method: 'GET',
+          path: '/api/posts',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            posts: [
+              {
+                id: 1,
+                title: 'Welcome to Wallflower',
+                content: 'This is the first post on our platform.',
+                authorId: 1,
+                createdAt: '2023-01-01T00:00:00Z',
+                updatedAt: '2023-01-01T00:00:00Z'
+              }
+            ],
+            pagination: {
+              page: 1,
+              limit: 10,
+              total: 1,
+              totalPages: 1
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return a list of posts', async () => {
+      const response = await axios.get('http://localhost:1235/api/posts', {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('posts');
+      expect(response.data).toHaveProperty('pagination');
+      expect(Array.isArray(response.data.posts)).toBe(true);
+      expect(response.data.posts[0]).toHaveProperty('id');
+      expect(response.data.posts[0]).toHaveProperty('title');
+      expect(response.data.posts[0]).toHaveProperty('content');
+      expect(response.data.posts[0]).toHaveProperty('authorId');
+      expect(response.data.posts[0]).toHaveProperty('createdAt');
+      expect(response.data.posts[0]).toHaveProperty('updatedAt');
+    });
+  });
+
+  describe('GET /api/posts/:id', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'post with ID 1 exists',
+        uponReceiving: 'a request for post with ID 1',
+        withRequest: {
+          method: 'GET',
+          path: '/api/posts/1',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            post: {
+              id: 1,
+              title: 'Welcome to Wallflower',
+              content: 'This is the first post on our platform.',
+              authorId: 1,
+              createdAt: '2023-01-01T00:00:00Z',
+              updatedAt: '2023-01-01T00:00:00Z'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return a specific post', async () => {
+      const response = await axios.get('http://localhost:1235/api/posts/1', {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('post');
+      expect(response.data.post).toHaveProperty('id', 1);
+      expect(response.data.post).toHaveProperty('title');
+      expect(response.data.post).toHaveProperty('content');
+      expect(response.data.post).toHaveProperty('authorId');
+    });
+  });
+
+  describe('POST /api/posts', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'user with ID 1 exists',
+        uponReceiving: 'a request to create a new post',
+        withRequest: {
+          method: 'POST',
+          path: '/api/posts',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: {
+            title: 'Test Post',
+            content: 'This is a test post content.',
+            authorId: 1
+          }
+        },
+        willRespondWith: {
+          status: 201,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            message: 'Post created successfully',
+            post: {
+              id: 3,
+              title: 'Test Post',
+              content: 'This is a test post content.',
+              authorId: 1,
+              createdAt: '2023-08-11T10:00:00Z',
+              updatedAt: '2023-08-11T10:00:00Z'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should create a new post', async () => {
+      const newPost = {
+        title: 'Test Post',
+        content: 'This is a test post content.',
+        authorId: 1
+      };
+
+      const response = await axios.post('http://localhost:1235/api/posts', newPost, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        }
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data).toHaveProperty('message', 'Post created successfully');
+      expect(response.data).toHaveProperty('post');
+      expect(response.data.post).toHaveProperty('id');
+      expect(response.data.post).toHaveProperty('title', 'Test Post');
+      expect(response.data.post).toHaveProperty('content', 'This is a test post content.');
+      expect(response.data.post).toHaveProperty('authorId', 1);
+      expect(response.data.post).toHaveProperty('createdAt');
+      expect(response.data.post).toHaveProperty('updatedAt');
+    });
+  });
+
+  describe('POST /api/posts - Validation Error', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'any state',
+        uponReceiving: 'a request to create a post with missing fields',
+        withRequest: {
+          method: 'POST',
+          path: '/api/posts',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: {
+            title: 'Test Post'
+            // Missing content and authorId
+          }
+        },
+        willRespondWith: {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            error: 'Validation error',
+            message: 'Title, content, and authorId are required'
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return validation error for incomplete post data', async () => {
+      const incompletePost = {
+        title: 'Test Post'
+        // Missing content and authorId
+      };
+
+      try {
+        await axios.post('http://localhost:1235/api/posts', incompletePost, {
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          }
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(400);
+        expect(error.response.data).toHaveProperty('error', 'Validation error');
+        expect(error.response.data).toHaveProperty('message');
+      }
+    });
+  });
+});

--- a/tests/pact/consumer/users.consumer.pact.test.js
+++ b/tests/pact/consumer/users.consumer.pact.test.js
@@ -1,0 +1,231 @@
+const { Pact } = require('@pact-foundation/pact');
+const axios = require('axios');
+const path = require('path');
+
+describe('Users API Consumer Contract Tests', () => {
+  let provider;
+
+  beforeAll(() => {
+    provider = new Pact({
+      consumer: 'wallflower-frontend',
+      provider: 'wallflower-api',
+      port: 1234,
+      log: path.resolve(process.cwd(), 'logs', 'pact.log'),
+      dir: path.resolve(process.cwd(), 'pacts'),
+      logLevel: 'INFO',
+      spec: 2
+    });
+
+    return provider.setup();
+  });
+
+  afterAll(() => {
+    return provider.finalize();
+  });
+
+  afterEach(() => {
+    return provider.verify();
+  });
+
+  describe('GET /api/users', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'users exist',
+        uponReceiving: 'a request for all users',
+        withRequest: {
+          method: 'GET',
+          path: '/api/users',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            users: [
+              {
+                id: 1,
+                name: 'John Doe',
+                email: 'john@example.com',
+                role: 'user'
+              }
+            ],
+            pagination: {
+              page: 1,
+              limit: 10,
+              total: 1,
+              totalPages: 1
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return a list of users', async () => {
+      const response = await axios.get('http://localhost:1234/api/users', {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('users');
+      expect(response.data).toHaveProperty('pagination');
+      expect(Array.isArray(response.data.users)).toBe(true);
+      expect(response.data.users[0]).toHaveProperty('id');
+      expect(response.data.users[0]).toHaveProperty('name');
+      expect(response.data.users[0]).toHaveProperty('email');
+      expect(response.data.users[0]).toHaveProperty('role');
+    });
+  });
+
+  describe('GET /api/users/:id', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'user with ID 1 exists',
+        uponReceiving: 'a request for user with ID 1',
+        withRequest: {
+          method: 'GET',
+          path: '/api/users/1',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            user: {
+              id: 1,
+              name: 'John Doe',
+              email: 'john@example.com',
+              role: 'user'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return a specific user', async () => {
+      const response = await axios.get('http://localhost:1234/api/users/1', {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('user');
+      expect(response.data.user).toHaveProperty('id', 1);
+      expect(response.data.user).toHaveProperty('name');
+      expect(response.data.user).toHaveProperty('email');
+      expect(response.data.user).toHaveProperty('role');
+    });
+  });
+
+  describe('GET /api/users/:id - User not found', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'user with ID 999 does not exist',
+        uponReceiving: 'a request for user with ID 999',
+        withRequest: {
+          method: 'GET',
+          path: '/api/users/999',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            error: 'User not found',
+            message: 'User with ID 999 does not exist'
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return 404 for non-existent user', async () => {
+      try {
+        await axios.get('http://localhost:1234/api/users/999', {
+          headers: { 'Accept': 'application/json' }
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(404);
+        expect(error.response.data).toHaveProperty('error', 'User not found');
+        expect(error.response.data).toHaveProperty('message');
+      }
+    });
+  });
+
+  describe('POST /api/users', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'no user with email test@example.com exists',
+        uponReceiving: 'a request to create a new user',
+        withRequest: {
+          method: 'POST',
+          path: '/api/users',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: {
+            name: 'Test User',
+            email: 'test@example.com',
+            role: 'user'
+          }
+        },
+        willRespondWith: {
+          status: 201,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            message: 'User created successfully',
+            user: {
+              id: 4,
+              name: 'Test User',
+              email: 'test@example.com',
+              role: 'user'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should create a new user', async () => {
+      const newUser = {
+        name: 'Test User',
+        email: 'test@example.com',
+        role: 'user'
+      };
+
+      const response = await axios.post('http://localhost:1234/api/users', newUser, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        }
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data).toHaveProperty('message', 'User created successfully');
+      expect(response.data).toHaveProperty('user');
+      expect(response.data.user).toHaveProperty('id');
+      expect(response.data.user).toHaveProperty('name', 'Test User');
+      expect(response.data.user).toHaveProperty('email', 'test@example.com');
+      expect(response.data.user).toHaveProperty('role', 'user');
+    });
+  });
+});

--- a/tests/pact/provider/provider.verification.test.js
+++ b/tests/pact/provider/provider.verification.test.js
@@ -1,0 +1,96 @@
+const { Verifier } = require('@pact-foundation/pact');
+const path = require('path');
+const app = require('../../../server');
+
+describe('Wallflower API Provider Verification', () => {
+  let server;
+  const PORT = 3001;
+
+  beforeAll((done) => {
+    server = app.listen(PORT, () => {
+      console.log(`Provider server running on port ${PORT}`);
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  it('should validate the expectations of wallflower-frontend', () => {
+    const opts = {
+      provider: 'wallflower-api',
+      providerBaseUrl: `http://localhost:${PORT}`,
+      pactUrls: [
+        path.resolve(__dirname, '../../../pacts/wallflower-frontend-wallflower-api.json')
+      ],
+      providerVersion: '1.0.0',
+      publishVerificationResult: false,
+      providerVersionTags: ['main'],
+      stateHandlers: {
+        'users exist': () => {
+          // Set up state where users exist
+          console.log('Setting up state: users exist');
+          return Promise.resolve();
+        },
+        'user with ID 1 exists': () => {
+          // Set up state where user with ID 1 exists
+          console.log('Setting up state: user with ID 1 exists');
+          return Promise.resolve();
+        },
+        'user with ID 999 does not exist': () => {
+          // Set up state where user with ID 999 does not exist
+          console.log('Setting up state: user with ID 999 does not exist');
+          return Promise.resolve();
+        },
+        'no user with email test@example.com exists': () => {
+          // Set up state where no user with test@example.com exists
+          console.log('Setting up state: no user with email test@example.com exists');
+          return Promise.resolve();
+        },
+        'posts exist': () => {
+          // Set up state where posts exist
+          console.log('Setting up state: posts exist');
+          return Promise.resolve();
+        },
+        'post with ID 1 exists': () => {
+          // Set up state where post with ID 1 exists
+          console.log('Setting up state: post with ID 1 exists');
+          return Promise.resolve();
+        },
+        'user with email john@example.com exists': () => {
+          // Set up state where user with email john@example.com exists
+          console.log('Setting up state: user with email john@example.com exists');
+          return Promise.resolve();
+        },
+        'no user with email newuser@example.com exists': () => {
+          // Set up state where no user with email newuser@example.com exists
+          console.log('Setting up state: no user with email newuser@example.com exists');
+          return Promise.resolve();
+        },
+        'user is authenticated with valid token': () => {
+          // Set up state where user is authenticated
+          console.log('Setting up state: user is authenticated with valid token');
+          return Promise.resolve();
+        },
+        'any state': () => {
+          // Default state handler
+          console.log('Setting up state: any state');
+          return Promise.resolve();
+        }
+      },
+      requestFilter: (req, res, next) => {
+        // Add any request filtering/modification here
+        console.log(`Provider verification request: ${req.method} ${req.path}`);
+        next();
+      },
+      beforeEach: () => {
+        // Reset any state before each test
+        console.log('Resetting state before verification');
+        return Promise.resolve();
+      }
+    };
+
+    return new Verifier(opts).verifyProvider();
+  });
+});

--- a/tests/pact/templates/api.consumer.template.js
+++ b/tests/pact/templates/api.consumer.template.js
@@ -1,0 +1,247 @@
+/**
+ * PACT Consumer Test Template
+ * 
+ * This template provides a starting point for creating new PACT consumer tests
+ * for Wallflower APIs. Copy this file and modify it for your specific API.
+ * 
+ * Instructions:
+ * 1. Replace 'YourAPI' with the actual API name (e.g., 'Comments', 'Categories')
+ * 2. Replace 'your-api' with the actual API path (e.g., 'comments', 'categories')
+ * 3. Update the port number to avoid conflicts (use unique ports for each API)
+ * 4. Modify the test cases to match your API's endpoints and data structures
+ * 5. Update the provider states to match your API's requirements
+ */
+
+const { Pact } = require('@pact-foundation/pact');
+const axios = require('axios');
+const path = require('path');
+
+describe('YourAPI API Consumer Contract Tests', () => {
+  let provider;
+
+  beforeAll(() => {
+    provider = new Pact({
+      consumer: 'wallflower-frontend',
+      provider: 'wallflower-api',
+      port: 1240, // Use a unique port for each API test
+      log: path.resolve(process.cwd(), 'logs', 'pact.log'),
+      dir: path.resolve(process.cwd(), 'pacts'),
+      logLevel: 'INFO',
+      spec: 2
+    });
+
+    return provider.setup();
+  });
+
+  afterAll(() => {
+    return provider.finalize();
+  });
+
+  afterEach(() => {
+    return provider.verify();
+  });
+
+  describe('GET /api/your-api', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'your-api items exist',
+        uponReceiving: 'a request for all your-api items',
+        withRequest: {
+          method: 'GET',
+          path: '/api/your-api',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            items: [
+              {
+                id: 1,
+                name: 'Sample Item',
+                // Add other properties specific to your API
+                createdAt: '2023-01-01T00:00:00Z'
+              }
+            ],
+            pagination: {
+              page: 1,
+              limit: 10,
+              total: 1,
+              totalPages: 1
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return a list of your-api items', async () => {
+      const response = await axios.get('http://localhost:1240/api/your-api', {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('items');
+      expect(response.data).toHaveProperty('pagination');
+      expect(Array.isArray(response.data.items)).toBe(true);
+      expect(response.data.items[0]).toHaveProperty('id');
+      expect(response.data.items[0]).toHaveProperty('name');
+      // Add assertions for other properties specific to your API
+    });
+  });
+
+  describe('GET /api/your-api/:id', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'your-api item with ID 1 exists',
+        uponReceiving: 'a request for your-api item with ID 1',
+        withRequest: {
+          method: 'GET',
+          path: '/api/your-api/1',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            item: {
+              id: 1,
+              name: 'Sample Item',
+              // Add other properties specific to your API
+              createdAt: '2023-01-01T00:00:00Z'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return a specific your-api item', async () => {
+      const response = await axios.get('http://localhost:1240/api/your-api/1', {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty('item');
+      expect(response.data.item).toHaveProperty('id', 1);
+      expect(response.data.item).toHaveProperty('name');
+      // Add assertions for other properties specific to your API
+    });
+  });
+
+  describe('POST /api/your-api', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'valid data for creating your-api item',
+        uponReceiving: 'a request to create a new your-api item',
+        withRequest: {
+          method: 'POST',
+          path: '/api/your-api',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: {
+            name: 'New Item',
+            // Add other required properties for your API
+          }
+        },
+        willRespondWith: {
+          status: 201,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            message: 'Item created successfully',
+            item: {
+              id: 2,
+              name: 'New Item',
+              // Add other properties that would be returned
+              createdAt: '2023-08-11T10:00:00Z'
+            }
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should create a new your-api item', async () => {
+      const newItem = {
+        name: 'New Item',
+        // Add other required properties for your API
+      };
+
+      const response = await axios.post('http://localhost:1240/api/your-api', newItem, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        }
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data).toHaveProperty('message');
+      expect(response.data).toHaveProperty('item');
+      expect(response.data.item).toHaveProperty('id');
+      expect(response.data.item).toHaveProperty('name', 'New Item');
+      // Add assertions for other properties specific to your API
+    });
+  });
+
+  describe('Error Handling - 404 Not Found', () => {
+    beforeEach(() => {
+      const interaction = {
+        state: 'your-api item with ID 999 does not exist',
+        uponReceiving: 'a request for non-existent your-api item',
+        withRequest: {
+          method: 'GET',
+          path: '/api/your-api/999',
+          headers: {
+            'Accept': 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            error: 'Not Found',
+            message: 'Item with ID 999 does not exist'
+          }
+        }
+      };
+
+      return provider.addInteraction(interaction);
+    });
+
+    it('should return 404 for non-existent item', async () => {
+      try {
+        await axios.get('http://localhost:1240/api/your-api/999', {
+          headers: { 'Accept': 'application/json' }
+        });
+      } catch (error) {
+        expect(error.response.status).toBe(404);
+        expect(error.response.data).toHaveProperty('error');
+        expect(error.response.data).toHaveProperty('message');
+      }
+    });
+  });
+
+  // Add more test cases as needed:
+  // - PUT /api/your-api/:id (update)
+  // - DELETE /api/your-api/:id (delete)
+  // - Validation errors (400)
+  // - Authentication/Authorization errors (401/403)
+  // - Server errors (500)
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,20 @@
+// Jest setup file for PACT tests
+const path = require('path');
+
+// Set up PACT configuration
+process.env.PACT_DIR = path.resolve(__dirname, '../pacts');
+process.env.LOG_LEVEL = process.env.LOG_LEVEL || 'INFO';
+
+// Ensure pacts directory exists
+const fs = require('fs');
+if (!fs.existsSync(process.env.PACT_DIR)) {
+  fs.mkdirSync(process.env.PACT_DIR, { recursive: true });
+}
+
+// Global test timeout
+jest.setTimeout(30000);
+
+// Clean up after tests
+afterAll(() => {
+  // Any global cleanup can go here
+});


### PR DESCRIPTION
This PR introduces a comprehensive PACT contract testing setup for the Wallflower Express APIs.

Key highlights:
- Consumer PACT tests for Users, Posts, and Auth APIs
- Provider verification tests with state handlers
- Example API endpoints (users, posts, auth) and health checks
- Template for creating future consumer PACT tests
- Custom PACT test runner script
- Integration tests for basic API flows
- Updated README with instructions and PACT docs

How to run:
1. Install dependencies: `npm install`
2. Run consumer tests: `npm run test:pact:consumer`
3. Run provider verification: `npm run test:pact:provider`
4. Run all PACT tests: `npm run test:pact` or `node scripts/run-pact-tests.js`

Notes:
- PACT broker settings are stubbed via `.env.example`
- Pact files are generated to `pacts/`
- Tests use unique ports to avoid collisions

Please review and let me know if you'd like any changes. Once approved, we can integrate this into CI/CD to enforce contracts automatically.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author