### PR TITLE
feat(search): functional filters on search results page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import './App.css';
+import SearchResults from './pages/SearchResults';
 
 // Components
 const Header: React.FC = () => (
@@ -13,6 +14,7 @@ const Header: React.FC = () => (
         <Link to="/" className="nav-link" data-testid="nav-home">Home</Link>
         <Link to="/planner" className="nav-link" data-testid="nav-planner">Trip Planner</Link>
         <Link to="/about" className="nav-link" data-testid="nav-about">About</Link>
+        <Link to="/search" className="nav-link" data-testid="nav-search">Search</Link>
       </nav>
     </div>
   </header>
@@ -127,6 +129,7 @@ const App: React.FC = () => {
             <Route path="/" element={<Home />} />
             <Route path="/planner" element={<TripPlanner />} />
             <Route path="/about" element={<About />} />
+            <Route path="/search" element={<SearchResults />} />
           </Routes>
         </main>
       </div>

--- a/client/src/data/accommodations.ts
+++ b/client/src/data/accommodations.ts
@@ -1,0 +1,123 @@
+export type Amenity = 'WiFi' | 'Pool' | 'Parking' | 'Gym' | 'Breakfast' | 'Spa' | 'PetFriendly';
+
+export type Accommodation = {
+  id: string;
+  name: string;
+  city: string;
+  pricePerNight: number; // USD
+  starRating: number; // 1-5 hotel stars
+  customerRating: number; // 0-5 average review
+  amenities: Amenity[];
+  image?: string;
+};
+
+export const ACCOMMODATIONS: Accommodation[] = [
+  {
+    id: 'a1',
+    name: 'Grand Plaza Hotel',
+    city: 'Paris',
+    pricePerNight: 220,
+    starRating: 5,
+    customerRating: 4.7,
+    amenities: ['WiFi', 'Pool', 'Parking', 'Gym', 'Breakfast', 'Spa'],
+  },
+  {
+    id: 'a2',
+    name: 'Riverside Inn',
+    city: 'London',
+    pricePerNight: 140,
+    starRating: 3,
+    customerRating: 4.1,
+    amenities: ['WiFi', 'Breakfast', 'Parking'],
+  },
+  {
+    id: 'a3',
+    name: 'City Center Suites',
+    city: 'New York',
+    pricePerNight: 180,
+    starRating: 4,
+    customerRating: 4.3,
+    amenities: ['WiFi', 'Gym', 'Breakfast', 'Parking'],
+  },
+  {
+    id: 'a4',
+    name: 'Coastal Retreat',
+    city: 'Barcelona',
+    pricePerNight: 110,
+    starRating: 2,
+    customerRating: 3.9,
+    amenities: ['WiFi', 'Pool', 'Parking'],
+  },
+  {
+    id: 'a5',
+    name: 'Mountain View Lodge',
+    city: 'Zurich',
+    pricePerNight: 160,
+    starRating: 4,
+    customerRating: 4.5,
+    amenities: ['WiFi', 'Parking', 'Breakfast', 'PetFriendly'],
+  },
+  {
+    id: 'a6',
+    name: 'Old Town Boutique',
+    city: 'Prague',
+    pricePerNight: 95,
+    starRating: 3,
+    customerRating: 4.0,
+    amenities: ['WiFi', 'Breakfast'],
+  },
+  {
+    id: 'a7',
+    name: 'Seaside Spa Resort',
+    city: 'Nice',
+    pricePerNight: 250,
+    starRating: 5,
+    customerRating: 4.8,
+    amenities: ['WiFi', 'Pool', 'Spa', 'Gym', 'Breakfast', 'Parking'],
+  },
+  {
+    id: 'a8',
+    name: 'Airport Express Hotel',
+    city: 'Amsterdam',
+    pricePerNight: 120,
+    starRating: 3,
+    customerRating: 3.8,
+    amenities: ['WiFi', 'Parking', 'Breakfast'],
+  },
+  {
+    id: 'a9',
+    name: 'Business Hub Stay',
+    city: 'Singapore',
+    pricePerNight: 200,
+    starRating: 4,
+    customerRating: 4.6,
+    amenities: ['WiFi', 'Gym', 'Parking', 'Breakfast'],
+  },
+  {
+    id: 'a10',
+    name: 'Historic Charm Hotel',
+    city: 'Rome',
+    pricePerNight: 130,
+    starRating: 3,
+    customerRating: 4.2,
+    amenities: ['WiFi', 'Breakfast', 'PetFriendly'],
+  },
+  {
+    id: 'a11',
+    name: 'Urban Minimalist',
+    city: 'Berlin',
+    pricePerNight: 85,
+    starRating: 2,
+    customerRating: 3.6,
+    amenities: ['WiFi'],
+  },
+  {
+    id: 'a12',
+    name: 'Harbor Lights Hotel',
+    city: 'Sydney',
+    pricePerNight: 210,
+    starRating: 5,
+    customerRating: 4.9,
+    amenities: ['WiFi', 'Pool', 'Spa', 'Gym', 'Breakfast'],
+  },
+];

--- a/client/src/pages/SearchResults.css
+++ b/client/src/pages/SearchResults.css
@@ -1,0 +1,36 @@
+.search-page h2 { color: #2c3e50; }
+.layout { display: grid; grid-template-columns: 300px 1fr; gap: 2rem; }
+.filters { background: #f7f9fb; border: 1px solid #e6eef5; padding: 1rem; border-radius: 8px; position: sticky; top: 1rem; height: fit-content; }
+.filters section + section { margin-top: 1rem; }
+.filters h4 { margin: 0 0 .5rem 0; color: #34495e; }
+.chip { display: inline-flex; align-items: center; gap: .5rem; background: #ecf0f1; padding: .4rem .7rem; border-radius: 999px; margin: .2rem; cursor: pointer; user-select: none; }
+.chip.active { background: #3498db; color: white; }
+.chip input { display: none; }
+.option { display: inline-flex; align-items: center; gap: .5rem; margin: .2rem .6rem .2rem 0; cursor: pointer; }
+.option input { margin-right: .25rem; }
+.option.selected { font-weight: 600; }
+.price-range .row { display: flex; gap: .5rem; }
+.price-range input { width: 120px; padding: .5rem; border: 1px solid #d0d7de; border-radius: 6px; }
+.results-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+.clear-filters { background: #e74c3c; color: white; border: none; padding: .5rem .8rem; border-radius: 6px; cursor: pointer; }
+.clear-filters:disabled { background: #f1a6a0; cursor: not-allowed; }
+.results-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
+.result-card { display: grid; grid-template-columns: 100px 1fr; gap: .8rem; background: white; border: 1px solid #e6eef5; border-radius: 8px; padding: .8rem; box-shadow: 0 1px 2px rgba(0,0,0,0.03); transition: transform .15s ease, opacity .2s ease; }
+.result-card:hover { transform: translateY(-2px); }
+.result-media .img-placeholder { width: 100px; height: 100px; background: linear-gradient(135deg, #bdc3c7, #95a5a6); color: white; display:flex; align-items:center; justify-content:center; border-radius: 6px; font-weight: 700; }
+.result-header { display:flex; align-items:center; justify-content: space-between; }
+.result-title { margin: 0; font-size: 1.05rem; }
+.result-meta { display:flex; align-items:center; gap:.6rem; color: #2c3e50; }
+.rating-pill { background: #2ecc71; color: white; padding: .2rem .4rem; border-radius: 999px; font-size: .85rem; }
+.amenities { display:flex; flex-wrap: wrap; gap: .3rem; margin-top: .5rem; }
+.amenity-pill { background: #ecf0f1; padding: .2rem .4rem; border-radius: 999px; font-size: .8rem; }
+.fade-in { animation: fade .2s ease; }
+@keyframes fade { from { opacity: .6 } to { opacity: 1 } }
+.no-results { margin-top: 1rem; padding: 1rem; background: #fff6f6; border: 1px solid #ffddde; border-radius: 8px; }
+.link-button { background: none; border: none; color: #3498db; cursor: pointer; padding: 0 .25rem; }
+
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  .filters { position: static; }
+  .price-range input { width: 100%; }
+}

--- a/client/src/pages/SearchResults.tsx
+++ b/client/src/pages/SearchResults.tsx
@@ -1,0 +1,246 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ACCOMMODATIONS, type Accommodation, type Amenity } from '../data/accommodations';
+import './SearchResults.css';
+
+// Helpers to work with URLSearchParams
+const parseNumber = (val: string | null, fallback: number) => {
+  const n = val ? Number(val) : NaN;
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const useQuery = () => new URLSearchParams(useLocation().search);
+
+// Filter State Type
+interface FilterState {
+  starMin: number; // hotel stars >=
+  priceMin: number;
+  priceMax: number;
+  amenities: Amenity[]; // must include all
+  customerMin: number; // review rating >=
+}
+
+const ALL_AMENITIES: Amenity[] = ['WiFi', 'Pool', 'Parking', 'Gym', 'Breakfast', 'Spa', 'PetFriendly'];
+
+const defaultFilters: FilterState = {
+  starMin: 0,
+  priceMin: 0,
+  priceMax: 1000,
+  amenities: [],
+  customerMin: 0,
+};
+
+const toParams = (filters: FilterState) => {
+  const p = new URLSearchParams();
+  if (filters.starMin) p.set('starMin', String(filters.starMin));
+  if (filters.priceMin) p.set('priceMin', String(filters.priceMin));
+  if (filters.priceMax !== 1000) p.set('priceMax', String(filters.priceMax));
+  if (filters.amenities.length) p.set('amenities', filters.amenities.join(','));
+  if (filters.customerMin) p.set('customerMin', String(filters.customerMin));
+  return p;
+};
+
+const fromParams = (p: URLSearchParams): FilterState => {
+  const starMin = parseNumber(p.get('starMin'), defaultFilters.starMin);
+  const priceMin = parseNumber(p.get('priceMin'), defaultFilters.priceMin);
+  const priceMax = parseNumber(p.get('priceMax'), defaultFilters.priceMax);
+  const amenities = (p.get('amenities') || '')
+    .split(',')
+    .map(a => a.trim())
+    .filter(Boolean) as Amenity[];
+  const customerMin = parseNumber(p.get('customerMin'), defaultFilters.customerMin);
+  return { starMin, priceMin, priceMax, amenities, customerMin };
+};
+
+const matchesAllFilters = (item: Accommodation, f: FilterState) => {
+  if (item.starRating < f.starMin) return false;
+  if (item.pricePerNight < f.priceMin || item.pricePerNight > f.priceMax) return false;
+  if (item.customerRating < f.customerMin) return false;
+  if (f.amenities.length && !f.amenities.every(am => item.amenities.includes(am))) return false;
+  return true;
+};
+
+const Stars: React.FC<{ value: number }> = ({ value }) => (
+  <span aria-label={`Hotel star rating ${value}`}>{'★'.repeat(Math.round(value))}{'☆'.repeat(5 - Math.round(value))}</span>
+);
+
+const RatingPill: React.FC<{ value: number }> = ({ value }) => (
+  <span className="rating-pill" title={`${value.toFixed(1)} / 5`}>{value.toFixed(1)}</span>
+);
+
+const ResultCard: React.FC<{ item: Accommodation } & React.HTMLAttributes<HTMLDivElement>> = ({ item, ...rest }) => (
+  <div className="result-card" {...rest}>
+    <div className="result-media" aria-hidden>
+      <div className="img-placeholder">{item.city.slice(0,2).toUpperCase()}</div>
+    </div>
+    <div className="result-body">
+      <div className="result-header">
+        <h3 className="result-title">{item.name}</h3>
+        <Stars value={item.starRating} />
+      </div>
+      <div className="result-meta">
+        <div className="price">${item.pricePerNight}/night</div>
+        <RatingPill value={item.customerRating} />
+      </div>
+      <div className="amenities">
+        {item.amenities.map(a => (
+          <span key={a} className="amenity-pill">{a}</span>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const useSyncedFilters = () => {
+  const navigate = useNavigate();
+  const query = useQuery();
+
+  const readStorage = (): FilterState | null => {
+    try {
+      const raw = localStorage.getItem('wf:search:filters');
+      return raw ? JSON.parse(raw) as FilterState : null;
+    } catch { return null; }
+  };
+
+  const writeStorage = (f: FilterState) => {
+    try { localStorage.setItem('wf:search:filters', JSON.stringify(f)); } catch {}
+  };
+
+  const initial = (() => {
+    const fromUrl = fromParams(query);
+    const hasAny = Array.from(query.keys()).length > 0;
+    if (hasAny) return fromUrl;
+    return readStorage() || fromUrl;
+  })();
+
+  const [filters, setFilters] = useState<FilterState>(initial);
+
+  // sync from URL on navigation
+  useEffect(() => {
+    const next = fromParams(query);
+    const hasAny = Array.from(query.keys()).length > 0;
+    if (hasAny) setFilters(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useLocation().search]);
+
+  // push to URL and storage on change
+  useEffect(() => {
+    const p = toParams(filters);
+    const url = p.toString() ? `/search?${p}` : '/search';
+    navigate(url, { replace: true });
+    writeStorage(filters);
+  }, [filters, navigate]);
+
+  return [filters, setFilters] as const;
+};
+
+const SearchResults: React.FC = () => {
+  const [filters, setFilters] = useSyncedFilters();
+
+  const filtered = useMemo(() => ACCOMMODATIONS.filter(a => matchesAllFilters(a, filters)), [filters]);
+
+  const clearAll = () => setFilters(defaultFilters);
+
+  // Simple animation via CSS class toggle on list
+  const [animateKey, setAnimateKey] = useState(0);
+  useEffect(() => { setAnimateKey(k => k + 1); }, [filtered.length]);
+
+  const total = ACCOMMODATIONS.length;
+  const count = filtered.length;
+
+  return (
+    <div className="search-page" data-testid="search-results-page">
+      <div className="container">
+        <h2>Search Results</h2>
+        <div className="results-header">
+          <div className="results-count" data-testid="results-count">Showing {count} of {total} results</div>
+          <button className="clear-filters" onClick={clearAll} disabled={JSON.stringify(filters)===JSON.stringify(defaultFilters)} data-testid="clear-filters">
+            Clear All Filters
+          </button>
+        </div>
+        <div className="layout">
+          <aside className="filters" aria-label="Filters" data-testid="filters-panel">
+            <section>
+              <h4>Star Rating</h4>
+              <div className="star-options">
+                {[0,1,2,3,4,5].map(s => (
+                  <label key={s} className={`chip ${filters.starMin===s ? 'active' : ''}`}>
+                    <input type="radio" name="starMin" value={s} checked={filters.starMin===s} onChange={() => setFilters(f => ({...f, starMin: s}))} />
+                    {s===0 ? 'Any' : `${s}+`}
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <h4>Price Range ($/night)</h4>
+              <div className="price-range">
+                <div className="row">
+                  <label>
+                    Min
+                    <input type="number" min={0} max={filters.priceMax} value={filters.priceMin}
+                      onChange={(e) => setFilters(f => ({...f, priceMin: Math.min(Number(e.target.value)||0, f.priceMax)}))}
+                      data-testid="price-min"/>
+                  </label>
+                  <label>
+                    Max
+                    <input type="number" min={filters.priceMin} value={filters.priceMax}
+                      onChange={(e) => setFilters(f => ({...f, priceMax: Math.max(Number(e.target.value)||0, f.priceMin)}))}
+                      data-testid="price-max"/>
+                  </label>
+                </div>
+              </div>
+            </section>
+
+            <section>
+              <h4>Amenities</h4>
+              <div className="amenities-options">
+                {ALL_AMENITIES.map(a => (
+                  <label key={a} className={`option ${filters.amenities.includes(a) ? 'selected' : ''}`}>
+                    <input type="checkbox" checked={filters.amenities.includes(a)}
+                      onChange={(e) => setFilters(f => ({
+                        ...f,
+                        amenities: e.target.checked ? [...f.amenities, a] : f.amenities.filter(x => x!==a)
+                      }))}
+                      />
+                    {a}
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <h4>Customer Rating</h4>
+              <div className="rating-options">
+                {[0,3.5,4.0,4.5].map(r => (
+                  <label key={r} className={`chip ${filters.customerMin===r ? 'active' : ''}`}>
+                    <input type="radio" name="customerMin" value={r} checked={filters.customerMin===r}
+                      onChange={() => setFilters(f => ({...f, customerMin: r}))}
+                    />
+                    {r===0 ? 'Any' : `${r.toFixed(1)}+`}
+                  </label>
+                ))}
+              </div>
+            </section>
+          </aside>
+
+          <section className="results">
+            <div key={animateKey} className="results-grid fade-in" data-testid="results-grid">
+              {filtered.map(item => (
+                <ResultCard key={item.id} item={item} />
+              ))}
+            </div>
+            {filtered.length === 0 && (
+              <div className="no-results" data-testid="no-results">
+                No results match the current filters. Try adjusting or
+                <button className="link-button" onClick={clearAll}> clearing all filters</button>.
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchResults;


### PR DESCRIPTION
This PR implements functional client-side filtering on the Search Results page for the Wallflower app.

Key features:
- Star Rating filter (>= selected stars)
- Price Range filter (min/max inputs)
- Amenities filter (multi-select; item must include ALL selected)
- Customer Rating filter (>= selected rating)
- AND logic across all filters with real-time updates
- URL query param sync for deep links and shareability
- localStorage persistence to restore filters on refresh/navigation
- Results count display ("Showing X of Y results")
- Clear All Filters button
- Empty state when no results match
- Subtle fade-in animation on result changes

Technical:
- New SearchResults page (client/src/pages/SearchResults.tsx) + styles
- Sample dataset (client/src/data/accommodations.ts)
- Router update (/search) and header link
- Tests can hook onto data-testid attributes: search-results-page, filters-panel, results-count, results-grid, clear-filters, no-results

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author