### PR TITLE
chore(openai): replace SDK with direct fetch and robust error handling in /api/openai-test

### DIFF
--- a/server/routes/openaiTest.js
+++ b/server/routes/openaiTest.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const { prompt } = req.body;
+
+    const userPrompt = (typeof prompt === 'string' && prompt.trim()) ? prompt.trim() : 'write a haiku about ai';
+
+    const fetchRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: userPrompt }],
+        temperature: 0.7,
+      }),
+    });
+
+    const ct = fetchRes.headers.get('content-type') || '';
+    const raw = await fetchRes.text();
+
+    if (!fetchRes.ok) {
+      throw new Error(`HTTP ${fetchRes.status} ${fetchRes.statusText}\n${raw.slice(0, 400)}`);
+    }
+    if (!ct.includes('application/json')) {
+      throw new Error(`Non-JSON response:\n${raw.slice(0, 400)}`);
+    }
+
+    const data = JSON.parse(raw);
+
+    res.json({
+      success: true,
+      prompt: userPrompt,
+      response: data?.choices?.[0]?.message?.content || '',
+      usage: data?.usage,
+      model: data?.model,
+    });
+
+  } catch (error) {
+    console.error('OpenAI test error:', error);
+    res.status(500).json({ 
+      success: false,
+      error: 'Failed to call OpenAI API',
+      details: error.message 
+    });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
This PR replaces the OpenAI SDK call in the /api/openai-test endpoint with a direct fetch to the OpenAI REST API and comprehensive error handling.

Why
- More resilient to network/proxy issues
- Clear error messages with status and truncated body
- Safe handling of non-JSON responses

Changes
- server/routes/openaiTest.js: implement fetch-based call, JSON Content-Type validation, non-OK status handling, raw body preview (first 400 chars), and plain-text completion response

Behavior
- Maintains response shape expected by the client: { success, prompt, response, usage, model }

Env
- Uses process.env.OPENAI_API_KEY, no keys hardcoded


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author