### PR TITLE
docs(server): add .env.example with OPENAI_API_KEY and PORT

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,5 @@
+# Copy to server/.env and fill in values
+OPENAI_API_KEY=
+# Optional: override server port
+PORT=5000
+


### PR DESCRIPTION
Adds server/.env.example with OPENAI_API_KEY and PORT defaults to simplify local setup.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author