### PR TITLE
feat(trip-planner): configurable timeout + retry on abort/network

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,8 @@
 # Copy to server/.env and fill in values
 OPENAI_API_KEY=
 # Optional: override server port
+# Optional: override OpenAI timeout (ms)
+OPENAI_TIMEOUT_MS=45000
+
 PORT=5000
 


### PR DESCRIPTION
Follow-up to Trip Planner OpenAI integration:
- Make timeout configurable via OPENAI_TIMEOUT_MS (default 45s)
- Retry once on AbortError or transient network errors with 2s backoff
- Clearer timeout error message (504)

This should reduce "operation was aborted" errors and improve reliability.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author